### PR TITLE
Switch to Docker strategy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM centos:7
+
+EXPOSE 8080
+
+RUN INSTALL_PKGS="rh-python36 rh-python36-python-devel rh-python36-python-setuptools rh-python36-python-pip nss_wrapper \
+        httpd24 httpd24-httpd-devel httpd24-mod_ssl httpd24-mod_auth_kerb httpd24-mod_ldap \
+        httpd24-mod_session atlas-devel gcc-gfortran libffi-devel libtool-ltdl enchant snappy-devel gcc-c++" && \
+    yum install -y centos-release-scl && \
+    yum -y --setopt=tsflags=nodocs install --enablerepo=centosplus $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    # Remove centos-logos (httpd dependency) to keep image size smaller.
+    rpm -e --nodeps centos-logos && \
+    yum -y clean all --enablerepo='*'
+
+COPY requirements.txt /opt/app-root/requirements.txt
+
+WORKDIR /opt/app-root
+
+RUN source scl_source enable rh-python36 && \
+    pip --no-cache-dir install -r requirements.txt
+
+COPY . /opt/app-root
+
+USER 1001
+
+ENTRYPOINT [ "./run.sh" ]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+source scl_source enable rh-python36
+gunicorn wsgi --bind=0.0.0.0:8080 --access-logfile=- --config config.py


### PR DESCRIPTION
Let's get rid of the s2i strategy and go directly to Docker. This way we can install the snappy-devel package.

I'm not sure if we need all the packages listed there, though. I've taken the list from [s2i python3.6 image](https://github.com/sclorg/s2i-python-container/blob/master/3.6/Dockerfile).

@AparnaKarve, can you please take a look at this PR?

Also, there's an associated change switching the template to the Docker strategy as well: https://github.com/ManageIQ/aiops-deploy/issues/4