### PR TITLE
Fix Travis - Install snappy headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: python
 python:
   - '3.6'
+addons:
+  apt:
+    packages:
+      - libsnappy-dev
 install:
   - pip install pipenv
   - pipenv sync


### PR DESCRIPTION
Use Travis addon for apt to get `libsnappy-dev` installed on the machine so requirements can be built successfully.