### PR TITLE
Memory optimizations

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,6 @@ gunicorn = "*"
 marshmallow = "~=2.17.0"
 prometheus_client = "*"
 requests = ">=2.20.0"
-pandas = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2ddcb1dd8f4a0b8a99a3c00717ede3c5225624395f25ad4da5e3f52c546adc40"
+            "sha256": "0e0008d9609a56664d201d9cb496a921a2627c6e2a2436f8c282957b7142be14"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -115,80 +115,12 @@
             "index": "pypi",
             "version": "==2.17.0"
         },
-        "numpy": {
-            "hashes": [
-                "sha256:00a458d6821b1e87be873f2126d5646b901047a7480e8ae9773ecf214f0e19f3",
-                "sha256:0470c5dc32212a08ebc2405f32e8ceb9a5b1c8ac61a2daf9835ec0856a220495",
-                "sha256:24a9c287a4a1c427c2d45bf7c4fc6180c52a08fa0990d4c94e4c86a9b1e23ba5",
-                "sha256:25600e8901012180a1b7cd1ac3e27e7793586ecd432383191929ac2edf37ff5d",
-                "sha256:2d279bd99329e72c30937bdef82b6dc7779c7607c5a379bab1bf76be1f4c1422",
-                "sha256:32af2bcf4bb7631dac19736a6e092ec9715e770dcaa1f85fcd99dec5040b2a4d",
-                "sha256:3e90a9fce378114b6c2fc01fff7423300515c7b54b7cc71b02a22bc0bd7dfdd8",
-                "sha256:5774d49516c37fd3fc1f232e033d2b152f3323ca4c7bfefd7277e4c67f3c08b4",
-                "sha256:64ff21aac30d40c20ba994c94a08d439b8ced3b9c704af897e9e4ba09d10e62c",
-                "sha256:803b2af862dcad6c11231ea3cd1015d1293efd6c87088be33d713a9b23e9e419",
-                "sha256:95c830b09626508f7808ce7f1344fb98068e63143e6050e5dc3063142fc60007",
-                "sha256:96e49a0c82b4e3130093002f625545104037c2d25866fa2e0c90d6e54f5a1fbc",
-                "sha256:a1dd8221f0e69038748f47b8bb3248d0b9ecdf13fe837440951c3d5ff72639bb",
-                "sha256:a80ecac5664f420556a725a5646f2d1c60a7c0489d68a38b5056393e949e27ac",
-                "sha256:b19a47ff1bd2fca0cacdfa830c967746764c32dca6a0c0328d9c893f4bfe2f6b",
-                "sha256:be43df2c563e264b38e3318574d80fc8f365df3fb745270934d2dbe54e006f41",
-                "sha256:c40cb17188f6ae3c5b6efc6f0fd43a7ddd219b7807fe179e71027849a9b91afc",
-                "sha256:c6251e0f0ecac53ba2b99d9f0cc16fa9021914a78869c38213c436ba343641f0",
-                "sha256:cb189bd98b2e7ac02df389b6212846ab20661f4bafe16b5a70a6f1728c1cc7cb",
-                "sha256:ef4ae41add536cb825d8aa029c15ef510aead06ea5b68daea64f0b9ecbff17db",
-                "sha256:f00a2c21f60284e024bba351875f3501c6d5817d64997a0afe4f4355161a8889",
-                "sha256:f1232f98a6bbd6d1678249f94028bccc541bbc306aa5c4e1471a881b0e5a3409",
-                "sha256:fea682f6ddc09517df0e6d5caad9613c6d91a42232aeb082df67e4d205de19cc"
-            ],
-            "version": "==1.16.0"
-        },
-        "pandas": {
-            "hashes": [
-                "sha256:02d34a55e85819a7eab096f391f8dcc237876e8b3cdaf1fba964f5fb59af9acf",
-                "sha256:0dbcf78e68f619840184ce661c68c1760de403b0f69d81905d6b9a699d1861d6",
-                "sha256:174c3974da26fd778ac8537d74efb17d4cef59e6b3e81e3c59690f39a6f6b73d",
-                "sha256:3a8ab5c350131ba273d3f8eb430343304d6c2138a61d34e4a11ebd75f8bf3e7e",
-                "sha256:560074ce9ff95409b233c0a8d143a2546a2d71d636d583172252dc0021fdb11b",
-                "sha256:5bded8cb431705609dbd9048114f1d6d59bef2f1ca95a8c58bd649442c9dc16c",
-                "sha256:8a8748684787792f3a643a7e0530c3024301f3e5799a199a5c2c526c07f712ba",
-                "sha256:8c7e43c4b7920fc02ce7743b976aca15bd45293ed298d84793307bc9799df3f6",
-                "sha256:9bd9ef3e183b7b1ce90b7ab5e8672907cd73dc36f036fc6714f0e7a5f9852da0",
-                "sha256:d3f27e276c8557c15c19c5c9a414e77b893d39fce6e6e40e5c46fcf5eeffe028",
-                "sha256:d40b82a4aee4ca968348e41bf6588ed9cadd171c7da8b671ed31d3fd967de703",
-                "sha256:d8cf054a099ff694a0e75386471bdde098efe7c350548ec6b899f169bef1a859",
-                "sha256:dd9f4843aa59f09698679b64064f11f51d60e45358ab45299de4dcff90524be3",
-                "sha256:e6f9f5ad4e73f5eecaa66e9c9d30ff8661c400190a6079ee170e37a466457e31",
-                "sha256:e9989e17f203900b2c7add53fa17d6686e66282598359b43fb12260ae8bf7eba",
-                "sha256:eadc9d19b25420e1ae77f0a11b779d4e71f47c3aa1953c218e8fe812d1f5341e",
-                "sha256:ecb630a99b0ab6c178b5c2988ca8c5b98f6ec2fd9e172c2873a5df44b261310f",
-                "sha256:f8eb9308bd64abf71dda77b823913696cd85c4f36c026acee0a64d8834a09b43",
-                "sha256:fe71a037ce866d9fb717fd3a792d46c744433179bf3f25da48af8f46cee20c3e",
-                "sha256:ff0d83306bfda4639fac2a4f8df2c51eb2bbdda540a74490703e8a6b413a37eb"
-            ],
-            "index": "pypi",
-            "version": "==0.24.0"
-        },
         "prometheus-client": {
             "hashes": [
                 "sha256:e8c11ff5ca53de6c3d91e1510500611cafd1d247a937ec6c588a0a7cc3bef93c"
             ],
             "index": "pypi",
             "version": "==0.5.0"
-        },
-        "python-dateutil": {
-            "hashes": [
-                "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
-                "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
-            ],
-            "version": "==2.7.5"
-        },
-        "pytz": {
-            "hashes": [
-                "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
-                "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
-            ],
-            "version": "==2018.9"
         },
         "requests": {
             "hashes": [
@@ -197,13 +129,6 @@
             ],
             "index": "pypi",
             "version": "==2.21.0"
-        },
-        "six": {
-            "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
-            ],
-            "version": "==1.12.0"
         },
         "urllib3": {
             "hashes": [

--- a/custom_parser/tar_gz_csv.py
+++ b/custom_parser/tar_gz_csv.py
@@ -1,9 +1,10 @@
 import tarfile
+from io import BytesIO
 from itertools import chain
 import pandas as pd
 
 
-def csv_parser(filename):
+def csv_parser(file_obj: BytesIO) -> list:
     """Extract CSV data from TAR.GZ file.
 
     Extracts all CSV files from a TAR.GZ archive and combines them into a list
@@ -11,7 +12,7 @@ def csv_parser(filename):
     :param filename: Name of the filename to parse
     """
     entries = list()
-    with tarfile.open(filename) as tar:
+    with tarfile.open(fileobj=file_obj) as tar:
         for member in tar:
             # Only CSV files are interesting
             if not member.name.endswith('.csv'):

--- a/custom_parser/tar_gz_csv.py
+++ b/custom_parser/tar_gz_csv.py
@@ -1,17 +1,20 @@
+import json
 import tarfile
 from io import BytesIO
-from itertools import chain
+
 import pandas as pd
 
 
-def csv_parser(file_obj: BytesIO) -> list:
+def csv_parser(file_obj: BytesIO) -> bytes:
     """Extract CSV data from TAR.GZ file.
 
     Extracts all CSV files from a TAR.GZ archive and combines them into a list
     of dictionary objects.
     :param filename: Name of the filename to parse
     """
-    entries = list()
+    # Start data stream
+    yield b'['
+
     with tarfile.open(fileobj=file_obj) as tar:
         for member in tar:
             # Only CSV files are interesting
@@ -20,6 +23,10 @@ def csv_parser(file_obj: BytesIO) -> list:
 
             # Read the CSV
             csv_data = pd.read_csv(tar.extractfile(member))
-            entries = chain(entries, csv_data.to_dict('records'))
 
-    return list(entries)
+            for item in csv_data.itertuples(index=False):
+                out_str = json.dumps(item._asdict())
+                yield f'{out_str},'.encode()
+
+    # End data stream
+    yield b']'


### PR DESCRIPTION
Current way of parsing the received file is inefficient. This Pr provides means to optimize memory usage and improve time costs per job.

## Means used to improve efficiency

These are the changes I've made along with the reasoning behind.

### Remove tempfile logic [`e6a3822`](https://github.com/ManageIQ/aiops-data-collector/pull/16/commits/e6a38229d49fdf4e5d1c9a3c3857db597d2717c2)

_Red series in the chart_

This is more of a code cleanup. The presumption is that once we receive the file it doesn't make any sense to store it as a temp file, because in containerized environment the `/tmp` partition is a `tmpfs` type - the data are stored in memory nevertheless. Therefore, we won't save much memory if we would dump the data in a file and then do our parsing over this tempfile.

Using a temfile would save us the HTTP response data overhead - a bit less memory due to `tmpfs` optimization on OS level. But it takes more time to process the data - it takes time to store the file and load it again.

### Use chunked stream [`864e93c`](https://github.com/ManageIQ/aiops-data-collector/pull/16/commits/864e93c911f6552ba415700623b2015c5ccb5183)

_Yellow series_

Unfortunately, if we want to parse the `*.csv` we need to load it fully into memory. But when we do so, we don't need to parse it as a whole. Instead we can parse each line as a separate entry. This way we don't need to keep the whole output file in memory and we can instead stream each entry separately in a chunked manner. Our memory usage then lowers to "just":
- whole `*.tar.gz` in memory
- whole `*.csv` in memory
- one entry parsed at a time

This approach greatly lowers memory usage, since it takes much space to store whole file while parsed. Pandas and Numpy are root cause of this issue. We've used them for the parsing instead of the standard `csv` package, because that one doesn't handle well data conversions... This issue is completely avoided with the last optimization:
 
### Avoid parsing to JSON and stream chunked binary data [`f0705eb`](https://github.com/ManageIQ/aiops-data-collector/pull/16/commits/f0705eb56a7ca36bb421d216455ad364fbe69179)

_Green series_

The parsing would be done once more on the AI service side nevertheless. Hence it doesn't make much sense to do it twice just so we can have neater, readable output of the `data-collector`. Since the parsing would consume time and resources in the AI service, the data collector can skip that part and just unpack the file and dump the binary data as a stream. We can chunk the reads of the `*.csv` - limit to a buffer size. The size limit can be used to balance memory spikes to time it takes to finish the job.

Memory and time savings are huge since the parsing is really costly operation and we're about to avoid that.

## Benchmark

To see how each optimization performs, we should do some benchmark. For that I've chose to use the Titanic dataset once more, just layered the data... So I've extended the data set by the same data so I've end up with a file:

Metric | Value
----- | -----
Total size of `titanic_extra_big.tar.gz` when compressed | 66MiB
Inner `titanic.csv` when unpacked | 211MiB
Inner `titanic.csv` entries total | 4436774 lines + 1 header

So as you can see it's really sparse and not much unique. That helps with compression so it shortens the time it takes to pass the file over the network. Also the impact of storing the file locally is lowered as well.

Now, let's see how each of the optimizations performs:

![chart 1](https://user-images.githubusercontent.com/7453394/51982879-7d28d380-2497-11e9-8d28-0e0d1b689d08.png)

Optimization | Memory peak for the same job
---------------- | ------------------
**Master** for comparison | 4433.92MiB
**No temp file** | 5092.35MiB
**Chunked parsed stream** | 1115.14MiB
**Raw binary stream** |  134MiB

It's worth mentioning the data were collected using `docker stats` which have a refresh rate of approx. a second. So the peak you see in the **No temp file** series may have (and probably did) occurred in the **Master** as well, it just wasn't caught.

Optimization | Time to complete a job
---------------- | ------------------
**Master** for comparison | 137s
**No temp file** | 135s
**Chunked parsed stream** | 23s
**Raw binary stream** | 18s

## Conclusion

As shown, chunked stream performs far better than parsing whole file at once. That is a valid observation no matter if we choose to parse the data or just dump it raw.

All these approaches results in the same, consumable output. Due to change in data format, only the last **Raw binary stream** optimization would require a small change in the AI service.

The residual memory increase after a job is completed, is something worth looking at. It seems the garbage collector in Python doesn't work well when the `Thread` objects are nod joined back... This should be addressed in future.
