### PR TITLE
first cut for topological inventory data collection

### DIFF
--- a/topology_inventory/__init__.py
+++ b/topology_inventory/__init__.py
@@ -1,0 +1,5 @@
+"""Metrics interface."""
+
+from .topology_inventory import TopologyInventoryClient
+
+__all__ = ["TopologyInventoryClient"]

--- a/topology_inventory/topology_inventory.py
+++ b/topology_inventory/topology_inventory.py
@@ -1,0 +1,81 @@
+# Invokes an internal API that returns data-points pertinent to what is
+# formally referred to as "Topological Inventory". Concordant data-sets
+# have actionable value in downstream analytics and use-cases.
+
+import os
+import json
+import requests
+
+import urllib3
+from urllib3.connectionpool import InsecureRequestWarning
+
+
+class TopologyInventoryClient:
+    """'Topological Inventory' data-set Client.
+
+    A client that invokes an internal API and returns data related to the
+    'Topological Inventory' data-set.
+
+    """
+
+    def __init__(self, username, password, endpoint):
+        """Initialize key values."""
+        # glue together into a single end-point
+        endpoint_with_credentials = "https://{}:{}@{}".format(
+            username,
+            password,
+            endpoint
+        )
+
+        self.endpoint_with_credentials = endpoint_with_credentials
+
+    def query_path(self, *paths):
+        """Query the Topological Inventory API.
+
+        Queries the Topological Inventory API given a user-defined path. The
+        path is defined by that in the ManageIQ swagger.yaml documentation:
+        https://github.com/ManageIQ/topological_inventory-api/blob/master/public/doc/swagger-2-v0.0.1.yaml
+
+        Args:
+            paths (list): REST path(s) wishing to be queries.
+
+        Examples
+        --------
+            client = TopologyInventoryClient()
+
+            # get all `containers` elements
+            client.query_path('containers')
+
+            # get all `container_group` elements
+            client.query_path('container_groups')
+
+            # get where `container_nodes` := 2, and return as DataFrame
+            client.query_path('container_nodes', '2')
+
+        Returns
+        -------
+            dict
+
+        """
+        try:
+            # the API executes an insecure request, so disable such warnings
+            urllib3.disable_warnings(InsecureRequestWarning)
+
+            # fetch a data-set given the REST endpoint
+            endpoint = os.path.join(self.endpoint_with_credentials, *paths)
+            response = requests.get(endpoint, verify=False)
+
+            response.raise_for_status()
+
+            # get REST response
+            out = response.json()
+
+            # if response is not a sequence, i.e. scalar or hash, cast as list
+            if not isinstance(out, list):
+                out = [out]
+
+            return out
+
+        # raised if the end-point is invalid or not JSON compatible
+        except json.decoder.JSONDecodeError:
+            return None

--- a/topology_inventory/topology_inventory.py
+++ b/topology_inventory/topology_inventory.py
@@ -79,3 +79,9 @@ class TopologyInventoryClient:
         # raised if the end-point is invalid or not JSON compatible
         except json.decoder.JSONDecodeError:
             return None
+
+    def noop(self):
+        """No OP."""
+        # Suppresses R0903 Too few public methods (1/2) [pylint]
+        # This is a temporary addition until we decide how
+        # to suppress this

--- a/topology_json_schema/__init__.py
+++ b/topology_json_schema/__init__.py
@@ -1,0 +1,5 @@
+"""Collect JSON Schema interface."""
+
+from .topology_json_schema import TopologyJSONSchema
+
+__all__ = ["TopologyJSONSchema"]

--- a/topology_json_schema/topology_json_schema.py
+++ b/topology_json_schema/topology_json_schema.py
@@ -1,0 +1,9 @@
+from marshmallow import Schema, fields
+
+
+class TopologyJSONSchema(Schema):
+    """Schema for Topology."""
+
+    username = fields.String(required=True)
+    password = fields.String(required=True)
+    endpoint = fields.String(required=True)

--- a/workers.py
+++ b/workers.py
@@ -117,3 +117,75 @@ def download_job(source_url: str, source_id: str, dest_url: str) -> None:
 
     thread = Thread(target=worker)
     thread.start()
+
+
+def topology_client_download(topology_client, entity: str) -> list:
+    """Download a list for a Topological Inventory Entity."""
+    return topology_client.query_path(entity)
+
+
+def download_topological_inventory_data(
+        topology_client,
+        source_id: str,
+        dest_url: str
+) -> None:
+    """Spawn a thread worker for data downloading Topological Inventory Data.
+
+    Requests the data to be downloaded and pass it to the next service
+    :param topology_client: Instance of TopologyInventoryClient
+           to assist downloading data
+    :param source_id: Data identifier
+    :param dest_url: Location where the collected data should be received
+    """
+    # When source_id is missing, create our own
+    source_id = source_id or str(uuid4())
+
+    def worker() -> None:
+        """Download, extract data and forward the content."""
+        thread = current_thread()
+        logger.debug('%s: Worker started', thread.name)
+
+        # Fetch data
+        entities = ["container_nodes",
+                    "volume_attachments",
+                    "volumes",
+                    "volume_types"]
+
+        topology_client_data = {}
+
+        for entity in entities:
+            prometheus_metrics.METRICS['gets'].inc()
+            try:
+                topology_client_data[entity] =\
+                    topology_client_download(topology_client, entity)
+                prometheus_metrics.METRICS['get_successes'].inc()
+            except requests.HTTPError as exception:
+                prometheus_metrics.METRICS['get_errors'].inc()
+                logger.error(
+                    '%s: Unable to fetch source data for "%s": %s',
+                    thread.name, source_id, exception
+                )
+                return
+
+        # Build the POST data object
+        data = {
+            'id': source_id,
+            'data': topology_client_data
+        }
+
+        # Pass to next service
+        prometheus_metrics.METRICS['posts'].inc()
+        try:
+            _retryable('post', f'http://{dest_url}', json=data)
+            prometheus_metrics.METRICS['post_successes'].inc()
+        except requests.HTTPError as exception:
+            logger.error(
+                '%s: Failed to pass data for "%s": %s',
+                thread.name, source_id, exception
+            )
+            prometheus_metrics.METRICS['post_errors'].inc()
+
+        logger.debug('%s: Done, exiting', thread.name)
+
+    thread = Thread(target=worker)
+    thread.start()


### PR DESCRIPTION
First cut for data collection using topological inventory API

`TopologyInventoryClient` was mostly used as is from https://gitlab.cee.redhat.com/AICoE/jupyter-notebooks/blob/457474f6a88464b31ad92c82f7570be348c3dd42/ocp4-usecases/aws-volume-type-validation.ipynb. Note that all the `pandas` references from the original implementation were removed keeping #16 in mind.

New environment variables -

- `DATA_COLLECTION_TYPE = 'TOPOLOGY'`
   To collect Topological Inventory data

- `USERNAME`
- `PASSWORD`
- `TOPOLOGY_INVENTORY_ENDPOINT`
   username/password/endpoint to establish connection with the Toplogical Inventory server