### PR TITLE
Add `x-rh-identity` to the post request header

### DIFF
--- a/server.py
+++ b/server.py
@@ -70,8 +70,7 @@ def post_collect():
     next_service = APP.config['NEXT_MICROSERVICE_HOST']
     source_id = input_data.get('payload_id')
 
-    b64_identity = request.headers['x-rh-identity'] \
-        if request.headers.get('x-rh-identity') else None
+    b64_identity = request.headers.get('x-rh-identity')
 
     workers.download_job(
         input_data['url'],

--- a/server.py
+++ b/server.py
@@ -57,7 +57,6 @@ def post_collect():
     """Endpoint servicing data collection."""
     input_data = request.get_json(force=True)
     validation = SCHEMA.load(input_data)
-
     prometheus_metrics.METRICS['jobs_total'].inc()
 
     if validation.errors:
@@ -71,7 +70,15 @@ def post_collect():
     next_service = APP.config['NEXT_MICROSERVICE_HOST']
     source_id = input_data.get('payload_id')
 
-    workers.download_job(input_data['url'], source_id, next_service)
+    b64_identity = request.headers['x-rh-identity'] \
+        if request.headers.get('x-rh-identity') else None
+
+    workers.download_job(
+        input_data['url'],
+        source_id,
+        next_service,
+        b64_identity
+    )
     APP.logger.info('Job started.')
 
     prometheus_metrics.METRICS['jobs_initiated'].inc()

--- a/workers.py
+++ b/workers.py
@@ -49,7 +49,7 @@ def download_job(
         source_url: str,
         source_id: str,
         dest_url: str,
-        b64_identity: str
+        b64_identity: str = None
 ) -> None:
     """Spawn a thread worker for data downloading task.
 
@@ -57,7 +57,7 @@ def download_job(
     :param source_url: Data source location
     :param source_id: Data identifier
     :param dest_url: Location where the collected data should be received
-    :param b64_identity: Identity in the request header
+    :param b64_identity: Redhat Identity base64 string
     """
     # When source_id is missing, create our own
     source_id = source_id or str(uuid4())

--- a/workers.py
+++ b/workers.py
@@ -45,13 +45,19 @@ def _retryable(method: str, *args, **kwargs) -> requests.Response:
     raise requests.HTTPError('All attempts failed')
 
 
-def download_job(source_url: str, source_id: str, dest_url: str) -> None:
+def download_job(
+        source_url: str,
+        source_id: str,
+        dest_url: str,
+        b64_identity: str
+) -> None:
     """Spawn a thread worker for data downloading task.
 
     Requests the data to be downloaded and pass it to the next service
     :param source_url: Data source location
     :param source_id: Data identifier
     :param dest_url: Location where the collected data should be received
+    :param b64_identity: Identity in the request header
     """
     # When source_id is missing, create our own
     source_id = source_id or str(uuid4())
@@ -100,7 +106,12 @@ def download_job(source_url: str, source_id: str, dest_url: str) -> None:
         # Pass to next service
         prometheus_metrics.METRICS['posts'].inc()
         try:
-            resp = _retryable('post', f'http://{dest_url}', json=data)
+            resp = _retryable(
+                'post',
+                f'http://{dest_url}',
+                json=data,
+                headers={"x-rh-identity": b64_identity}
+            )
             prometheus_metrics.METRICS['post_successes'].inc()
         except requests.HTTPError as exception:
             logger.error(


### PR DESCRIPTION
With 3scale integration, we are required to pass the `x-rh-identity` value to the POST request header.

The value would have to be propagated all the way through aiops-publisher, which it can then use to call the Upload service