### PR TITLE
`url` is an optional parameter hence retrieve using `.get('url')`

### DIFF
--- a/server.py
+++ b/server.py
@@ -73,7 +73,7 @@ def post_collect():
     b64_identity = request.headers.get('x-rh-identity')
 
     workers.download_job(
-        input_data['url'],
+        input_data.get('url'),
         source_id,
         next_service,
         b64_identity


### PR DESCRIPTION
Realized that this should have been done in #20, since `url` is an optional input parameter now

@tumido Please review. 

When using topological inventory data as the data source, we can now make the POST call without any  JSON data, as shown below -

```
curl --user <username>:<password> -X POST https://api.access.qa.cloud.paas.upshift.redhat.com/r/insights/platform/aiops-data-collector/api/v0/collect
```