### PR TITLE
Add Travis notifications to #aiops_bots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: python
 python:
-  - '3.6'
-addons:
-  apt:
-    packages:
-      - libsnappy-dev
+- '3.6'
 install:
-  - pip install pipenv
-  - pipenv sync
-  - pipenv sync --dev
+- pip install pipenv
+- pipenv sync
+- pipenv sync --dev
 script:
-  - pylama
+- pylama
+notifications:
+  slack:
+    secure: Yg27E+vlRnZ8x4WcGd1Uv/oVnubmNu8zAf+7p6bQClGtCNKUqBLaKJVCcnteZhZgDi7JjSfRbmeZyto2dnaxbauEN5zmOhjFDSL+3VZiy0x/sYVxeysIDFu7THixanZiM29Hwsk+9tZYIs+RQJqryjkvYk18Auj/bQ5KWVBwDiMKI15uWhUK69mX4vCiuMmyjU0+/i5mCPBygc5hmu5jT3mJ5UhOvCNj88klA/Wkd1IV+BYJrY6wtIzOmp2PyOkNi/ivxxq7bthCr00LOj2XNW3Q1tBOBCDWe5+X62KK7pCPsp0Z7eyFf8Obuw+l99Q86kgMWAzXextnNZ/5J5hs9P7VfdITtw++7khAt7k6PgULwiH/OJYj9fNpJWvW5fdMXC8zldGQAzZkr8pn8XgcdCO9kLOL0GdWDVukRCvg108DEbIWaBy6ncB/4Jq4UtfVzEOg3QM9LPj1i1dN18UNh2Wk4PStzW4J87zE+KLEVJshkuSkFeCQnLaX3SBgU1pnZSq70z62Ma30CBj+lKq0d4A24izQb/omlHjNYATHlHGIp59+FhBroozjSlk++34nKJn6ygEhVhwXzzNvYdcZtZw6EQByL5VO1D++XdLo8fLTuJmeYg4EW3a3BCvt4at21aisqyfgcyc8YZV9V/GpevH3ieA++IBvqTJEi8LxHS4=
+    on_pull_requests: false


### PR DESCRIPTION
Let's try out the TravisCI bot for Slack. This can post job build status similarly as we had it before in the ManageIQ land - it's gonna land in Slack as a message to the `#aiops_bots`.

Includes a Travis yaml cleanup (`libsnappy` is not needed anymore).

Related: https://github.com/ManageIQ/aiops-incoming-listener/pull/16, 