### PR TITLE
Add Pagination API and sub collection query support

### DIFF
--- a/target_worker/__init__.py
+++ b/target_worker/__init__.py
@@ -14,6 +14,7 @@ logger = logging.getLogger()
 if os.environ.get('INPUT_DATA_FORMAT') == 'TOPOLOGY':
     logger.info('Target Worker is Topology')
 
+    HOST = os.environ.get('TOPOLOGY_INVENTORY_HOST')
     ENDPOINT = os.environ.get('TOPOLOGY_INVENTORY_ENDPOINT')
 
     if not ENDPOINT:
@@ -23,6 +24,7 @@ if os.environ.get('INPUT_DATA_FORMAT') == 'TOPOLOGY':
 
     NAME = 'worker_topology'
     INFO = {
+        'host': HOST,
         'endpoint': ENDPOINT,
         'queries': {
             'container_nodes': 'archived_at',

--- a/target_worker/__init__.py
+++ b/target_worker/__init__.py
@@ -27,12 +27,36 @@ if os.environ.get('INPUT_DATA_FORMAT') == 'TOPOLOGY':
         'host': HOST,
         'endpoint': ENDPOINT,
         'queries': {
-            'container_nodes': 'archived_at',
-            'volume_attachments': '',
-            'volumes': 'archived_at',
-            'volume_types': '',
-            'vms': 'archived_at',
-            'sources': ''
+            'container_nodes': {
+                'main_collection': 'container_nodes',
+                'query_string': 'archived_at'
+            },
+            'container_nodes_tags': {
+                'main_collection': 'container_nodes',
+                'sub_collection': 'tags',
+                'foreign_key': 'container_node_id',
+                'query_string': ''
+            },
+            'volume_attachments': {
+                'main_collection': 'volume_attachments',
+                'query_string': ''
+            },
+            'volumes': {
+                'main_collection': 'volumes',
+                'query_string': 'archived_at'
+            },
+            'volume_types': {
+                'main_collection': 'volume_types',
+                'query_string': ''
+            },
+            'vms': {
+                'main_collection': 'vms',
+                'query_string': 'archived_at'
+            },
+            'sources': {
+                'main_collection': 'sources',
+                'query_string': ''
+            }
         }
     }
 

--- a/workers.py
+++ b/workers.py
@@ -44,6 +44,100 @@ def _retryable(method: str, *args, **kwargs) -> requests.Response:
     raise requests.HTTPError('All attempts failed')
 
 
+def query_main_collection(
+        host: str,
+        endpoint: str,
+        main_collection: str,
+        query_string: str
+) -> dict:
+    """Query a Collection.
+
+    Returns a Response object with data retrieved from all pages
+    :param host: The host
+    :param endpoint: API Endpoint
+    :param main_collection: Collection name ('container_nodes', 'sources' etc)
+    :param query_string: Query string as additional params to the GET request
+    :return: Response object with data retrieved from all pages
+    :raises: HTTPError in the function caller
+    """
+    # First GET call to get data as well as pagination links
+    resp = _retryable(
+        'get',
+        f'{host}{endpoint}/{main_collection}',
+        params={query_string: ''},
+        verify=False
+    )
+    out = resp.json()
+    all_data = out['data']
+    prometheus_metrics.METRICS['get_successes'].inc()
+
+    # Subsequent GET calls that reference the pagination link
+    while out['links'].get('next'):
+        resp = _retryable(
+            'get',
+            f'{host}{out["links"]["next"]}',
+            verify=False
+        )
+        out = resp.json()
+        all_data += out['data']
+        prometheus_metrics.METRICS['get_successes'].inc()
+    return all_data
+
+
+def query_sub_collection(
+        host: str,
+        endpoint: str,
+        main_collection: str,
+        sub_collection: str,
+        query_string: str,
+        collection: list,
+        foreign_key: str
+) -> dict:
+    """Query a SubCollection for all records in the main collection.
+
+    Returns a Response object with data retrieved from all pages
+    :param host: The host
+    :param endpoint: API Endpoint
+    :param main_collection: Collection name ('container_nodes', 'sources' etc)
+    :param sub_collection: Sub-Collection name ('tags')
+    :param query_string: Query string as additional params to the GET request
+    :param collection: List of all main collection items
+    :param foreign_key: Foreign key to be added to sub-collection records
+    :return: Response object with sub-collection data retrieved from all pages
+    :raises: HTTPError in the function caller
+    """
+    all_data = []
+    for item in collection:
+        # First GET call to get data as well as pagination links
+        resp = _retryable(
+            'get',
+            f'{host}{endpoint}'
+            f'/{main_collection}/{item["id"]}/{sub_collection}',
+            params={query_string: ''},
+            verify=False
+        )
+        out = resp.json()
+
+        for row in enumerate(out['data']):
+            row[1][foreign_key] = item['id']
+        all_data += out['data']
+        prometheus_metrics.METRICS['get_successes'].inc()
+
+        # Subsequent GET calls that reference the pagination link
+        while out['links'].get('next'):
+            resp = _retryable(
+                'get',
+                f'{host}{out["links"]["next"]}',
+                verify=False
+            )
+            out = resp.json()
+            for row in enumerate(out['data']):
+                row[1][foreign_key] = item['id']
+            all_data += out['data']
+            prometheus_metrics.METRICS['get_successes'].inc()
+    return all_data
+
+
 def download_job(
         source_url: str,
         source_id: str,
@@ -117,36 +211,29 @@ def download_job(
             'data': {}
         }
 
+        host = topology_info["host"]
+        endpoint = topology_info["endpoint"]
+
         for entity in topology_info['queries'].keys():
             prometheus_metrics.METRICS['gets'].inc()
 
-            query_string = topology_info['queries'][entity]
-            try:
-                # First GET call to get data as well as pagination links
-                resp = _retryable(
-                    'get',
-                    f'{topology_info["host"]}{topology_info["endpoint"]}'
-                    f'/{entity}',
-                    params={query_string: ''},
-                    verify=False
-                )
-                out = resp.json()
-                print("out = ")
-                print(out)
-                all_data = out['data']
-                prometheus_metrics.METRICS['get_successes'].inc()
+            query_entity = topology_info['queries'][entity]
+            query_string = query_entity.get('query_string')
+            main_collection = query_entity.get('main_collection')
+            sub_collection = query_entity.get('sub_collection')
+            foreign_key = query_entity.get('foreign_key')
+
+            if sub_collection:
                 try:
-                    # Subsequent GET calls that reference the pagination link
-                    while out['links'].get('next'):
-                        resp = _retryable(
-                            'get',
-                            f'{topology_info["host"]}{out["links"]["next"]}',
-                            verify=False
-                        )
-                        out = resp.json()
-                        all_data += out['data']
-                        data['data'][entity] = all_data
-                        prometheus_metrics.METRICS['get_successes'].inc()
+                    all_data = query_sub_collection(
+                        host,
+                        endpoint,
+                        main_collection,
+                        sub_collection,
+                        query_string,
+                        data['data'][main_collection],
+                        foreign_key
+                    )
                 except requests.HTTPError as exception:
                     prometheus_metrics.METRICS['get_errors'].inc()
                     logger.error(
@@ -154,13 +241,23 @@ def download_job(
                         thread.name, source_id, exception
                     )
                     return
-            except requests.HTTPError as exception:
-                prometheus_metrics.METRICS['get_errors'].inc()
-                logger.error(
-                    '%s: Unable to fetch source data for "%s": %s',
-                    thread.name, source_id, exception
-                )
-                return
+            else:
+                try:
+                    all_data = query_main_collection(
+                        host,
+                        endpoint,
+                        main_collection,
+                        query_string
+                    )
+                except requests.HTTPError as exception:
+                    prometheus_metrics.METRICS['get_errors'].inc()
+                    logger.error(
+                        '%s: Unable to fetch source data for "%s": %s',
+                        thread.name, source_id, exception
+                    )
+                    return
+
+            data['data'][entity] = all_data
 
         # Pass to next service
         prometheus_metrics.METRICS['posts'].inc()


### PR DESCRIPTION
The PR contains two prominent changes -
 - Uses Topology Inventory API v0.1 that supports pagination
 - Added 2 separate methods to : 
   - Query a collection (e.g. `container_nodes`, `vms` etc)
   - Query a sub-collection (e.g. `container_nodes/1/tags`)

The sub-collection method fixes the issue reported in [AIOPS-107](https://projects.engineering.redhat.com/browse/AIOPS-107)

Other notes -
- API v0.1 enforces pagination, which means multiple GET requests for multiple pages to get the dataset for a given entity. This has some pros and cons.
  - Pros: Smaller JSON payloads
  - Cons: Multiple Requests can add overhead in terms of performance
- These changes should also help us for OCP Use Case#2 -- Instance type validation