### PR TITLE
Adjust data collector API endpoints to the new scheme

### DIFF
--- a/server.py
+++ b/server.py
@@ -26,7 +26,7 @@ ROOT_LOGGER.addHandler(default_handler)
 
 VERSION = "0.0.1"
 
-ROUTE_PREFIX = "/r/insights/platform/aiops-data-collector"
+ROUTE_PREFIX = "/api/aiops-data-collector"
 
 # Schema for the Collect API
 SCHEMA = CollectJSONSchema()
@@ -42,7 +42,7 @@ def get_root():
     )
 
 
-@APP.route(f'{ROUTE_PREFIX}/api/v0/version', methods=['GET'])
+@APP.route(f'{ROUTE_PREFIX}/v0/version', methods=['GET'])
 def get_version():
     """Endpoint for getting the current version."""
     return jsonify(
@@ -52,7 +52,7 @@ def get_version():
     )
 
 
-@APP.route(f'{ROUTE_PREFIX}/api/v0/collect', methods=['POST'])
+@APP.route(f'{ROUTE_PREFIX}/v0/collect', methods=['POST'])
 def post_collect():
     """Endpoint servicing data collection."""
     input_data = request.get_json(force=True)

--- a/swagger.yml
+++ b/swagger.yml
@@ -1,7 +1,7 @@
 swagger: '2.0'
-basePath: /r/insights/platform/aiops-data-collector
+basePath: /api/aiops-data-collector
 paths:
-  /api/v0/collect:
+  /v0/collect:
     post:
       responses:
         '200':
@@ -27,7 +27,7 @@ paths:
       operationId: get_root
       tags:
       - default
-  /api/v0/version:
+  /v0/version:
     get:
       responses:
         '200':


### PR DESCRIPTION
Change API endpoint to the new format. Basically:
1. `s/r\/insights\/platform/api/`
2. `s/api\/v0/v0/`

Related: https://github.com/RedHatInsights/e2e-deploy/pull/137