### PR TITLE
Make the PATH_PREFIX configurable

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -47,7 +47,7 @@ paths:
       - default
 info:
   title: AIOPS Data Collector API
-  version: 0.1
+  version: '0.1'
   description: AIOPS Data Collector API
 produces:
   - application/json

--- a/swagger.yml
+++ b/swagger.yml
@@ -1,7 +1,7 @@
 swagger: '2.0'
-basePath: /api/aiops-data-collector
+basePath: /
 paths:
-  /v0/collect:
+  /v0.1/collect:
     post:
       responses:
         '200':
@@ -27,7 +27,7 @@ paths:
       operationId: get_root
       tags:
       - default
-  /v0/version:
+  /v0.1/version:
     get:
       responses:
         '200':
@@ -47,7 +47,7 @@ paths:
       - default
 info:
   title: AIOPS Data Collector API
-  version: 0.0.1
+  version: 0.1
   description: AIOPS Data Collector API
 produces:
   - application/json


### PR DESCRIPTION
According to [IPP-12](https://docs.google.com/document/d/1sEgro5-lXYJGsxOdxFOcyz7EHilrnpBVkHT_m2IXogk) and [IPP-?](https://docs.google.com/document/d/1YnTpRqRmsQij23L2Dsm6V5adBUvMdjlQQgdRqgyCGSA) we're required to provide option to:
- `PATH_PREFIX` should be configurable for the deployment as env. variable
- `APP_NAME` env variable should be used when path prefix is specified
- API version should be in `MAJOR.MINOR` format.


The way it should work now is that when `PATH_PREFIX` is specified, routes are: `aiops-data-collector.svc:8080:/<PATH_PREFIX>/<APP_NAME>/v<API_VERSION>/...`. So for example for Volume type validation this would be:
```
aiops-data-collector.svc:8080:/api/aiops-volume-type-validation/v0.1/collect
```

If the `PATH_PREFIX` is not specified, please consider it as a dev/local deployment. At that case, we use:
```
aiops-data-collector.svc:8080/v0.1/collect
```

We follow the IPPs now, and I've adopted the same way as topological inventory uses this. 

Related: https://github.com/RedHatInsights/e2e-deploy/pull/142