### PR TITLE
Data collection for idle cost savings

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,6 +5,7 @@ bind = '127.0.0.1:8000'
 
 workers = int(os.environ.get('GUNICORN_PROCESSES', '3'))
 threads = int(os.environ.get('GUNICORN_THREADS', '1'))
+timeout = 120
 
 forwarded_allow_ips = '*'
 secure_scheme_headers = {'X-Forwarded-Proto': 'https'}

--- a/server.py
+++ b/server.py
@@ -15,6 +15,8 @@ def create_application():
     app = Flask(__name__)
     app.config['NEXT_MICROSERVICE_HOST'] = \
         os.environ.get('NEXT_MICROSERVICE_HOST')
+    app.config['APP_NAME'] = \
+        os.environ.get('APP_NAME')
 
     return app
 
@@ -73,6 +75,7 @@ def post_collect():
         ), 400
 
     next_service = APP.config['NEXT_MICROSERVICE_HOST']
+    app_name = APP.config['APP_NAME']
     source_id = input_data.get('payload_id')
 
     b64_identity = request.headers.get('x-rh-identity')
@@ -81,6 +84,7 @@ def post_collect():
         input_data.get('url'),
         source_id,
         next_service,
+        app_name,
         b64_identity
     )
     APP.logger.info('Job started.')

--- a/target_worker/__init__.py
+++ b/target_worker/__init__.py
@@ -26,6 +26,28 @@ if os.environ.get('INPUT_DATA_FORMAT') == 'TOPOLOGY':
     INFO = {
         'host': HOST,
         'endpoint': ENDPOINT,
+        'queries_by_app': {
+            'aiops-volume-type-validation': [
+                'container_nodes',
+                'container_nodes_tags',
+                'vms',
+                'sources',
+                'volume_attachments',
+                'volumes',
+                'volume_types'
+            ],
+            'aiops-idle-cost-savings': [
+                'container_nodes',
+                'container_nodes_tags',
+                'vms',
+                'sources',
+                'container_groups',
+                'containers',
+                'container_resource_quotas',
+                'container_projects',
+                'flavors'
+            ]
+        },
         'queries': {
             'container_nodes': {
                 'main_collection': 'container_nodes',
@@ -55,6 +77,27 @@ if os.environ.get('INPUT_DATA_FORMAT') == 'TOPOLOGY':
             },
             'sources': {
                 'main_collection': 'sources',
+                'query_string': ''
+            },
+            'container_groups': {
+                'main_collection': 'container_groups',
+                'query_string': 'archived_at'
+            },
+            'containers': {
+                'main_collection': 'container_groups',
+                'sub_collection': 'containers',
+                'query_string': 'archived_at'
+            },
+            'container_resource_quotas': {
+                'main_collection': 'container_resource_quotas',
+                'query_string': 'archived_at'
+            },
+            'container_projects': {
+                'main_collection': 'container_projects',
+                'query_string': 'archived_at'
+            },
+            'flavors': {
+                'main_collection': 'flavors',
                 'query_string': ''
             }
         }

--- a/workers.py
+++ b/workers.py
@@ -172,6 +172,7 @@ def download_job(
         source_url: str,
         source_id: str,
         dest_url: str,
+        app_name: str,
         b64_identity: str = None
 ) -> None:
     """Spawn a thread worker for data downloading task.
@@ -244,7 +245,7 @@ def download_job(
         host = topology_info["host"]
         endpoint = topology_info["endpoint"]
 
-        for entity in topology_info['queries'].keys():
+        for entity in topology_info['queries_by_app'][app_name]:
             prometheus_metrics.METRICS['gets'].inc()
 
             query_entity = topology_info['queries'][entity]


### PR DESCRIPTION
Data collector changes for Idle Cost Savings

Idle Cost Savings needs to query the following entities -
```
                'container_nodes',
                'container_nodes_tags',
                'vms',
                'sources',
                'container_groups',
                'containers',
                'container_resource_quotas',
                'container_projects',
                'flavors'
```

which is a different list than Volume Type Validation

It looks like the data-collector should know what use case it is dealing with within the `TOPOLOGY` realm, in order to avoid querying extra endpoints.

We could possibly set this list externally from the deployment template? 

The other thing to note is, while testing this in OpenShift I got the `CRITICAL WORKER TIMEOUT` error, and hence I had to add `timeout = 120` in config.py, which resolved the error.
There are about 1000+ GET requests being made for this use case (pagination and querying sub-collections are the main reasons for this high count)

