### PR TITLE
Added env GUNICORN_WORKER to open up for other worker_class

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,8 +4,7 @@ import os
 bind = '127.0.0.1:8000'
 
 workers = int(os.environ.get('GUNICORN_PROCESSES', '3'))
-threads = int(os.environ.get('GUNICORN_THREADS', '1'))
-timeout = 120
+worker_class = os.environ.get('GUNICORN_WORKER', 'gthread')
 
 forwarded_allow_ips = '*'
 secure_scheme_headers = {'X-Forwarded-Proto': 'https'}


### PR DESCRIPTION
To allow using e.g. `gthread` worker_class to prevent long running worker being shutdown