### PR TITLE
query `vms` endpoint first to bail out early

### DIFF
--- a/collector/configs/topological_app_config.yml
+++ b/collector/configs/topological_app_config.yml
@@ -1,16 +1,16 @@
 aiops-volume-type-validation:
+  - vms
   - container_nodes
   - container_nodes_tags
-  - vms
   - sources
   - volume_attachments
   - volumes
   - volume_types
 
 aiops-idle-cost-savings:
+  - vms
   - container_nodes
   - container_nodes_tags
-  - vms
   - sources
   - container_groups
   - containers
@@ -19,11 +19,11 @@ aiops-idle-cost-savings:
   - flavors
 
 aiops-instance-type-validation:
+  - vms
   - container_nodes
   - container_nodes_tags
   - container_images
   - container_images_tags
   - container_groups
   - containers
-  - vms
   - sources


### PR DESCRIPTION
This change is based purely on an observation that some accounts have -
- x number of container_nodes,
- y number of containers,
- z number of  pick_your_favorite_endpoint and,
- 0 VMs

In an event we get 0 records for an endpoint, we bail out from the data collection for that account with a debug log message saying-
`Inadequate Topological Inventory data for this account.`

The `vms` endpoint is queried towards the end in most Topology Inventory use cases.
If we query `vms` first, and get 0 records, we could bail out early from the data collection process for that account and avoid querying the other endpoints (which would now be considered unnecessary)

To give a better idea, these are the Before and After logs for Account 540155

Before -
```
[2019-04-25 15:38:22,206] DEBUG in topological_inventory: Thread-3: ---START Account# 540155---
[2019-04-25 15:38:22,231] INFO in topological_inventory: Thread-3: a09eb212-fffd-4b17-8b30-22b313cc29d4: container_nodes        3
[2019-04-25 15:38:22,311] INFO in topological_inventory: Thread-3: a09eb212-fffd-4b17-8b30-22b313cc29d4: container_nodes_tags   24
[2019-04-25 15:38:22,797] INFO in topological_inventory: Thread-3: a09eb212-fffd-4b17-8b30-22b313cc29d4: container_images       237
[2019-04-25 15:38:30,214] INFO in topological_inventory: Thread-3: a09eb212-fffd-4b17-8b30-22b313cc29d4: container_images_tags  6660
[2019-04-25 15:38:30,377] INFO in topological_inventory: Thread-3: a09eb212-fffd-4b17-8b30-22b313cc29d4: container_groups       52
[2019-04-25 15:38:31,273] INFO in topological_inventory: Thread-3: a09eb212-fffd-4b17-8b30-22b313cc29d4: containers     70
[2019-04-25 15:38:31,286] INFO in topological_inventory: Thread-3: a09eb212-fffd-4b17-8b30-22b313cc29d4: vms    0
[2019-04-25 15:38:31,286] DEBUG in topological_inventory: Thread-3: Inadequate Topological Inventory data for this account.
[2019-04-25 15:38:31,289] DEBUG in topological_inventory: Thread-3: ---END Account# 540155---
```

After -
```
[2019-04-25 19:58:15,383] DEBUG in topological_inventory: Thread-1: ---START Account# 540155---
[2019-04-25 19:58:15,401] INFO in topological_inventory: Thread-1: b636ef7b-52f7-4aed-8a46-2a97e18a3f6a: vms    0
[2019-04-25 19:58:15,401] DEBUG in topological_inventory: Thread-1: Inadequate Topological Inventory data for this account.
[2019-04-25 19:58:15,402] DEBUG in topological_inventory: Thread-1: ---END Account# 540155---
```

