### PR TITLE
set redis cache for all accounts that are processed

### DIFF
--- a/collector/topological_inventory.py
+++ b/collector/topological_inventory.py
@@ -226,12 +226,13 @@ def worker(_: str, source_id: str, dest: str, acct_info: dict) -> None:
                          thread.name, tenant_header['acct_no'])
             headers = tenant_header['headers']
             topological_inventory_data(_, source_id, dest, headers, thread)
+            utils.set_processed(tenant_header['acct_no'])
             LOGGER.debug('%s: ---END Account# %s---',
                          thread.name, tenant_header['acct_no'])
     else:
         LOGGER.info('Fetching data for current Tenant')
         topological_inventory_data(_, source_id, dest, headers, thread)
-    utils.set_processed(account_id)
+        utils.set_processed(account_id)
     LOGGER.debug('%s: Done, exiting', thread.name)
 
 


### PR DESCRIPTION
With Topology data collection, we can fetch data for all the tenants/accounts with a single data-collection run. Redis needs to cache all these account numbers that are processed.

After applying this PR, Redis is successfully caching all account numbers as shown below -
<img width="1129" alt="Screen Shot 2019-05-08 at 12 08 48 PM" src="https://user-images.githubusercontent.com/1538216/57401253-15ff7700-718a-11e9-8f65-3a1c20104d65.png">
