### PR TITLE
Prep the / (root) endpoint for Liveness and Readiness

### DIFF
--- a/collector/utils.py
+++ b/collector/utils.py
@@ -21,6 +21,15 @@ if not (REDIS_ENV and REDIS_PASSWORD):
 REDIS = redis.Redis(**json.loads(REDIS_ENV), password=REDIS_PASSWORD)
 
 
+def ping_redis() -> str:
+    """Call ping on Redis."""
+    try:
+        return REDIS.ping()
+    except redis.exceptions.ConnectionError as e:
+        LOGGER.warning('Redis Ping unsuccessful')
+        return False
+
+
 def processed(key: str) -> bool:
     """If an account has been processed within the window."""
     return REDIS.get(key)

--- a/collector/utils.py
+++ b/collector/utils.py
@@ -5,6 +5,7 @@ from threading import current_thread
 import sys
 import redis
 import requests
+from gunicorn.arbiter import Arbiter
 
 from .env import SSL_VERIFY, REDIS_ENV, REDIS_PASSWORD, PROCESS_WINDOW
 
@@ -16,7 +17,7 @@ requests.packages.urllib3.disable_warnings()
 
 if not (REDIS_ENV and REDIS_PASSWORD):
     LOGGER.error('Environment not set properly for Redis')
-    sys.exit(1)
+    sys.exit(Arbiter.APP_LOAD_ERROR)
 
 REDIS = redis.Redis(**json.loads(REDIS_ENV), password=REDIS_PASSWORD)
 

--- a/collector/utils.py
+++ b/collector/utils.py
@@ -2,9 +2,9 @@ import json
 import logging
 from threading import current_thread
 
+import sys
 import redis
 import requests
-import sys
 
 from .env import SSL_VERIFY, REDIS_ENV, REDIS_PASSWORD, PROCESS_WINDOW
 
@@ -25,7 +25,7 @@ def ping_redis() -> str:
     """Call ping on Redis."""
     try:
         return REDIS.ping()
-    except redis.exceptions.ConnectionError as e:
+    except redis.exceptions.ConnectionError:
         LOGGER.warning('Redis Ping unsuccessful')
         return False
 

--- a/collector/utils.py
+++ b/collector/utils.py
@@ -26,7 +26,7 @@ def ping_redis() -> str:
     """Call ping on Redis."""
     try:
         return REDIS.ping()
-    except redis.exceptions.ConnectionError:
+    except (redis.exceptions.ConnectionError, redis.exceptions.ResponseError):
         LOGGER.warning('Redis Ping unsuccessful')
         return False
 

--- a/collector/utils.py
+++ b/collector/utils.py
@@ -4,6 +4,7 @@ from threading import current_thread
 
 import redis
 import requests
+import sys
 
 from .env import SSL_VERIFY, REDIS_ENV, REDIS_PASSWORD, PROCESS_WINDOW
 
@@ -13,6 +14,9 @@ LOGGER = logging.getLogger()
 # pylama:ignore=E1101
 requests.packages.urllib3.disable_warnings()
 
+if not (REDIS_ENV and REDIS_PASSWORD):
+    LOGGER.error('Environment not set properly for Redis')
+    sys.exit(1)
 
 REDIS = redis.Redis(**json.loads(REDIS_ENV), password=REDIS_PASSWORD)
 

--- a/server.py
+++ b/server.py
@@ -41,11 +41,17 @@ if PATH_PREFIX:
 @APP.route(f'{ROUTE_PREFIX}/', methods=['GET'], strict_slashes=False)
 def get_root():
     """Root Endpoint for 3scale."""
+    if collector.utils.ping_redis():
+        return jsonify(
+            status='OK',
+            version=API_VERSION,
+            message='Up and Running'
+        )
     return jsonify(
-        status='OK',
+        status='Error',
         version=API_VERSION,
-        message='Up and Running'
-    )
+        message="Required service not operational"
+    ), 500
 
 
 @APP.route(f'{ROUTE_PREFIX}/v{API_VERSION}/version', methods=['GET'])


### PR DESCRIPTION
Liveness and Readiness can be effectively implemented if the service ends gracefully in the event of -
- Bad configuration
- Services that it depends on are not available

In the PR, `Redis` is being checked for availability.
We should perhaps add similar checks for both Topology Inventory Service and Host Inventory Service

e2edeploy PR - https://github.com/RedHatInsights/e2e-deploy/pull/342