### PR TITLE
Ping both Redis and also Next Service for a complete liveness/readiness check

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,8 @@ def patch_env(monkeypatch):
         TOPOLOGICAL_INVENTORY_HOST='http://topological:8080',
         TOPOLOGICAL_INVENTORY_PATH='api/topo/vX',
         HOST_INVENTORY_HOST='http://inventory:8080',
-        HOST_INVENTORY_PATH='api/inventory/vX'
+        HOST_INVENTORY_PATH='api/inventory/vX',
+        NEXT_SERVICE_URL='http://nextservice:8080'
     )
     for item, value in setenv.items():
         monkeypatch.setenv(item, value)


### PR DESCRIPTION
In addition to pinging the required service `Redis`, also ping `Next Service` (AI service), which completes the requirement of Liveness/Readiness health probe checks for aiops-data-collector

Fixes [AIOPS-119](https://projects.engineering.redhat.com/browse/AIOPS-119)

Requires https://github.com/ManageIQ/aiops-ai-library/pull/43 for Volume Type Validation