### PR TITLE
Topological collector cleanup

### DIFF
--- a/collector/utils.py
+++ b/collector/utils.py
@@ -41,6 +41,10 @@ def set_processed(key: str) -> None:
     REDIS.set(key, 1, ex=PROCESS_WINDOW)
 
 
+class DataMissingError(Exception):
+    """No data collected exception."""
+
+
 class RetryFailedError(requests.HTTPError):
     """Exception raised when the HTTP retry fails.
 


### PR DESCRIPTION
Cleanup the topological worker:

- [x] Generic `_collect_data` for paginated calls (no call to `_update_fk` anymore - preparation for paginated Tenants collection)
- [x] Move `tenant_header_info` to `create_tenant` - shorter name, docstring, creates tenant namedtuple object
- [x] Significant cleanup and code deduplication in `worker`. Follows worker API again (no return value).
