### PR TITLE
Topological inventory internal API v1

### DIFF
--- a/collector/env.py
+++ b/collector/env.py
@@ -1,6 +1,6 @@
 import os
 
-TENANTS_URL = os.environ.get('TENANTS_URL')
+TOPOLOGICAL_INTERNAL_PATH = os.environ.get('TOPOLOGICAL_INTERNAL_PATH')
 ALL_TENANTS = os.environ.get('ALL_TENANTS', 'true').lower() in ['true', 'y']
 TOPOLOGICAL_INVENTORY_HOST = os.environ.get('TOPOLOGICAL_INVENTORY_HOST')
 TOPOLOGICAL_INVENTORY_PATH = os.environ.get('TOPOLOGICAL_INVENTORY_PATH')

--- a/tests/collector/test_topological_inventory.py
+++ b/tests/collector/test_topological_inventory.py
@@ -314,20 +314,20 @@ class TestWorker:
             return_value=0
         )
         mock_redis = mocker.patch.object(utils, 'set_processed')
-        mock_response = mocker.Mock()
-        mock_retryable = mocker.patch.object(
-            utils, 'retryable', return_value=mock_response
+        mock_collect_data = mocker.patch.object(
+            topological_inventory, '_collect_data',
+            return_value=[
+                dict(external_tenant=i) for i in range(10)
+            ]
         )
-        mock_response.json.return_value = [
-            dict(external_tenant=i) for i in range(10)
-        ]
 
         topological_inventory.worker('', 'source_id', 'dest', account)
 
         assert mock_collector.call_count == 10
         mock_redis.assert_has_calls([mocker.call(i) for i in range(10)])
-        mock_retryable.assert_called_once_with(
-            'get', topological_inventory.TENANTS_URL, headers=mocker.ANY
+        mock_collect_data.assert_called_once_with(
+            topological_inventory.SERVICES_URL['TOPOLOGICAL_INTERNAL'],
+            'tenants', headers=mocker.ANY
         )
 
     def test_single_account(self, monkeypatch, mocker):


### PR DESCRIPTION
Topological inventory internal API moves to `v1.0`. With this change the `tenants` endpoint is paginated. Let's use the `_collect_data` to ingest the results and walk pages properly. 

Merge this after: https://github.com/RedHatInsights/e2e-deploy/pull/507